### PR TITLE
Website tabs add a link to docs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,12 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'prefer-promise-reject-errors': 'off',
 
+    // fix `Strings must use single quote`
+    "quotes": [1, "single"],
+    "quotes": [0, "double"],
+
+    // fix `'LF' but found 'CRLF' linebreak-style`
+    'linebreak-style': ["off", "windows"],
 
     // allow debugger during development only
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn-error.log*
 *.njsproj
 *.sln
 .vscode
+.history

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# FlowLauncher Website
+# Flow Launcher Website
 
-Home of FlowLauncher!
+Home of Flow Launcher!
 
-The FlowLauncher website is written with the wonderfull quasar framework. (Based on `vue.js`)
+The Flow Launcher website is written with the wonderfull quasar framework. (Based on `vue.js`)
 
 ## Setup Development Environment
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
-# FlowLauncher Website (flowlauncher-website)
+# FlowLauncher Website
 
 Home of FlowLauncher!
-The FlowLauncher website is written with the wonderfull quasar framework. (Based on vue.js)
 
-# Setup Development Environment
+The FlowLauncher website is written with the wonderfull quasar framework. (Based on `vue.js`)
 
-## Install the dependencies
+## Setup Development Environment
+
+### Install the dependencies
+
 ```bash
 yarn
 ```
 
 ### Start the app in development mode (hot-code reloading, error reporting, etc.)
+
 ```bash
 quasar dev
 ```
 
 ### Lint the files
+
 ```bash
 yarn run lint
 ```
 
 ### Build the app for production
+
 ```bash
 quasar build
 ```

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,8 +3,9 @@
     <router-view />
   </div>
 </template>
+
 <script>
 export default {
-  name: 'App',
+  name: "App",
 };
 </script>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
   <head>
     <title><%= productName %></title>
 
@@ -7,7 +8,8 @@
     <meta name="description" content="<%= productDescription %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>">
+    <meta name="viewport"
+      content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">
@@ -15,8 +17,10 @@
     <link rel="icon" type="image/png" sizes="16x16" href="icons/favicon-16x16.png">
     <link rel="icon" type="image/ico" href="favicon.ico">
   </head>
+
   <body>
     <!-- DO NOT touch the following DIV -->
     <div id="q-app"></div>
   </body>
+
 </html>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -37,6 +37,11 @@
             label="Download"
             @click="scrollToElement('download')"
           />
+          <q-route-tab
+            icon="mdi-file-document"
+            label="Document"
+            to="/docs"
+          />
         </q-tabs>
       </q-toolbar>
     </q-header>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,45 +2,66 @@
   <q-layout view="hHh lpR fFf">
     <q-header elevated>
       <q-toolbar class="bg-grey-9">
-
         <q-avatar square size="md">
-          <img alt="FlowLauncher Logo" src="/images/logo.svg">
+          <img alt="FlowLauncher Logo" src="/images/logo.svg" />
         </q-avatar>
 
-        <q-toolbar-title>
-          FlowLauncher
-        </q-toolbar-title>
+        <q-toolbar-title> FlowLauncher </q-toolbar-title>
 
-        <q-btn size="sm" flat stretch icon="mdi-github" type="a" href="https://github.com/Flow-Launcher/Flow.Launcher">
+        <q-btn
+          size="sm"
+          flat
+          stretch
+          icon="mdi-github"
+          type="a"
+          href="https://github.com/Flow-Launcher/Flow.Launcher"
+        >
           &nbsp;Flow-Launcher/Flow.Launcher
         </q-btn>
       </q-toolbar>
+
       <q-toolbar class="bg-secondary shadow-8">
         <q-tabs align="left" inline-label>
-          <q-tab icon="mdi-home" label="Start" @click="scrollToElement('home')" />
-          <q-tab icon="mdi-cogs" label="Features"  @click="scrollToElement('features')" />
-          <q-tab icon="mdi-download" label="Download"  @click="scrollToElement('download')" />
+          <q-tab
+            icon="mdi-home"
+            label="Start"
+            @click="scrollToElement('home')"
+          />
+          <q-tab
+            icon="mdi-cogs"
+            label="Features"
+            @click="scrollToElement('features')"
+          />
+          <q-tab
+            icon="mdi-download"
+            label="Download"
+            @click="scrollToElement('download')"
+          />
         </q-tabs>
       </q-toolbar>
     </q-header>
+
     <q-page-container>
       <router-view />
     </q-page-container>
-      <q-toolbar class="row bg-grey-10 text-grey-4 shadow-up-4">
-        <q-space />
-          <div class="col-md-2 text-center col-xs-6">The FlowLauncher Team © 2020</div>
-        <q-space />
+
+    <q-toolbar class="row bg-grey-10 text-grey-4 shadow-up-4">
+      <q-space />
+      <div class="col-md-2 text-center col-xs-6">
+        The FlowLauncher Team © 2020
+      </div>
+      <q-space />
     </q-toolbar>
   </q-layout>
 </template>
 
 <script>
-import { scroll } from 'quasar';
+import { scroll } from "quasar";
 
 const { getScrollTarget, setScrollPosition } = scroll;
 
 export default {
-  name: 'MainLayout',
+  name: "MainLayout",
   methods: {
     scrollToElement(el) {
       const element = document.getElementById(el);

--- a/src/pages/Error404.vue
+++ b/src/pages/Error404.vue
@@ -1,13 +1,11 @@
 <template>
-  <div class="fullscreen bg-blue text-white text-center q-pa-md flex flex-center">
+  <div
+    class="fullscreen bg-blue text-white text-center q-pa-md flex flex-center"
+  >
     <div>
-      <div style="font-size: 30vh">
-        404
-      </div>
+      <div style="font-size: 30vh">404</div>
 
-      <div class="text-h2" style="opacity:.4">
-        Oops. Nothing here...
-      </div>
+      <div class="text-h2" style="opacity: 0.4">Oops. Nothing here...</div>
 
       <q-btn
         class="q-mt-xl"
@@ -24,6 +22,6 @@
 
 <script>
 export default {
-  name: 'Error404',
+  name: "Error404",
 };
 </script>


### PR DESCRIPTION
## changelogs

1. format codes add white space for `.md`, `.html` and `.vue` file via language linter
2. rename `FlowLauncher` to `Flow Launcher`
3. add a link to **docs** in tabs
4. fix linebreak-style problem in win os