### PR TITLE
Add schemas for plugin.json and SettingsTemplate.yaml

### DIFF
--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "ID": {
+      "type": "string",
+      "oneOf": [
+        {
+          "pattern": "(?i)^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+        },
+        {
+          "pattern": "(?i)^[a-f0-9]{32}$"
+        }
+      ],
+      "description": "A unique identifier in the form of UUID so Flow Launcher can distinguish between plugins."
+    },
+    "ActionKeyword": {
+      "type": "string",
+      "description": "The keyword that triggers the plugin. If you want the plugin to trigger without the keyword, set this to *",
+      "minLength": 1,
+      "default": "*",
+      "examples": ["*", "myplugin", "web"]
+    },
+    "Name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "Description": {
+      "type": "string"
+    },
+    "Author": {
+      "type": "string",
+      "minLength": 1
+    },
+    "Version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "Language": {
+      "type": "string"
+    },
+    "Website": {
+      "type": "string",
+      "pattern": "^https?://.+$"
+    },
+    "ExecuteFileName": {
+      "type": "string"
+    },
+    "IcoPath": {
+      "type": "string",
+      "pattern": "(?i)[.]png$"
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "Language": {
+          "enum": [
+            "javascript",
+            "javascript_v2"
+          ]
+        },
+        "ExecuteFileName": {
+          "pattern": "(?i)[.][mc]?js$"
+        }
+      }
+    },
+    {
+      "properties": {
+        "Language": {
+          "enum": [
+            "typescript",
+            "typescript_v2"
+          ]
+        },
+        "ExecuteFileName": {
+          "pattern": "(?i)[.]([mc]?j|t)s$"
+        }
+      }
+    },
+    {
+      "properties": {
+        "Language": {
+          "enum": [
+            "python",
+            "python_v2"
+          ]
+        },
+        "ExecuteFileName": {
+          "pattern": "(?i)[.]pyc?$"
+        }
+      }
+    },
+    {
+      "properties": {
+        "Language": {
+          "enum": [
+            "executable",
+            "executable_v2"
+          ]
+        },
+        "ExecuteFileName": {
+          "pattern": "(?i)[.]exe$"
+        }
+      }
+    },
+    {
+      "properties": {
+        "Language": {
+          "enum": [
+            "csharp",
+            "fsharp"
+          ]
+        },
+        "ExecuteFileName": {
+          "pattern": "(?i)[.]dll$"
+        }
+      }
+    }
+  ],
+  "required": [
+    "ID",
+    "ActionKeyword",
+    "Name",
+    "Description",
+    "Author",
+    "Version",
+    "Language",
+    "Website",
+    "ExecuteFileName",
+    "IcoPath"
+  ]
+}

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -18,6 +18,7 @@
       "type": "string",
       "description": "The keyword that triggers the plugin. If you want the plugin to trigger without the keyword, set this to *",
       "minLength": 1,
+      "maxLength": 32,
       "default": "*",
       "examples": ["*", "myplugin", "web"]
     },

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -14,13 +14,15 @@
       ],
       "description": "A unique identifier in the form of UUID so Flow Launcher can distinguish between plugins."
     },
-    "ActionKeyword": {
-      "type": "string",
-      "description": "The keyword that triggers the plugin. If you want the plugin to trigger without the keyword, set this to *",
-      "minLength": 1,
-      "maxLength": 32,
-      "default": "*",
-      "examples": ["*", "myplugin", "web"]
+    "ActionKeywords": {
+      "type": "array",
+      "description": "The keywords that trigger the plugin. If you want the plugin to trigger without a keyword, set this to [\"*\"]",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "default": "*"
+      }
     },
     "Name": {
       "type": "string",
@@ -121,7 +123,7 @@
   ],
   "required": [
     "ID",
-    "ActionKeyword",
+    "ActionKeywords",
     "Name",
     "Description",
     "Author",

--- a/schemas/settings-template.schema.json
+++ b/schemas/settings-template.schema.json
@@ -6,7 +6,8 @@
       "properties": {
         "name": {
           "type": "string",
-          "pattern": "(?i)^[a-z_][a-z_0-9]*$"
+          "pattern": "(?i)^[a-z_][a-z_0-9]*$",
+          "maxLength": 64
         },
         "label": {
           "type": "string"
@@ -48,6 +49,8 @@
   "properties": {
     "body": {
       "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
       "items": {
         "type": "object",
         "required": [
@@ -65,13 +68,16 @@
                 "type": "object",
                 "properties": {
                   "description": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                   }
-                }
+                },
+                "required": ["description"]
               }
             },
             "required": [
-              "type"
+              "type",
+              "attributes"
             ]
           },
           {
@@ -100,6 +106,8 @@
                 "properties": {
                   "options": {
                     "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
                     "items": {
                       "type": ["string", "number", "boolean"]
                     }

--- a/schemas/settings-template.schema.json
+++ b/schemas/settings-template.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "commonProperties": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "(?i)^[a-z_][a-z_0-9]*$"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "defaultValue": {
+          "type": ["string", "number", "boolean"]
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "commonPropertiesBool": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "(?i)^[a-z_][a-z_0-9]*$"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "defaultValue": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "body": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "type",
+          "attributes"
+        ],
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "textBlock"
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": ["input", "inputWithFileBtn", "inputWithFolderBtn", "textarea", "passwordBox"]
+              },
+              "attributes": {
+                "$ref": "#/$defs/commonProperties"
+              }
+            },
+            "required": [
+              "type",
+              "attributes"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "dropdown"
+              },
+              "attributes": {
+                "$ref": "#/$defs/commonProperties",
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": ["string", "number", "boolean"]
+                    }
+                  }
+                },
+                "required": ["name", "options"]
+              }
+            },
+            "required": [
+              "type",
+              "attributes"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "checkbox"
+              },
+              "attributes": {
+                "$ref": "#/$defs/commonPropertiesBool"
+              }
+            },
+            "required": [
+              "type",
+              "attributes"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "required": [
+    "body"
+  ]
+}


### PR DESCRIPTION
This PR adds two files to host on the website. These files are JSON schemas that simplify working with `plugin.json` and `SettingsTemplate.yaml` when developing plugins. These files need to be hosted somewhere public, which is why I'm adding them here, so they can be accessed via flowlauncher.com domain.

## `plugin.json`
In `plugin.json` you can add the following property at the beginning of the object to get autocomplete and validation:
```json
"$schema": "https://www.flowlauncher.com/schemas/plugin.schema.json",
```
A few screenshots:
![image-1](https://github.com/user-attachments/assets/e487dffc-1de2-42fb-a2bc-58425fc05cd7)
![image](https://github.com/user-attachments/assets/b391d95a-d35a-488d-9bcf-ed5c0dc169b1)
![image-1](https://github.com/user-attachments/assets/f3f465c5-cb92-49dd-b759-fd06ab2b54eb)
![image](https://github.com/user-attachments/assets/fa039743-eda6-47b8-a08c-afc7a6280ac7)
![image-1](https://github.com/user-attachments/assets/f98ddd9f-2195-4eae-9ec5-42faa4410740)
![image](https://github.com/user-attachments/assets/cd422b8f-11ec-4a83-863e-68adf9e94704)

As far as I know, this works in JetBrains IDEs, Visual Studio, and Visual Studio Code.

## `SettingsTemplate.yaml`
Flow has some strict validation for this file that doesn't allow adding unknown properties, so you can't add `$scheme` here. Instead, add a comment at the beginning of the file:
```yaml
#$schema: https://www.flowlauncher.com/schemas/settings-template.schema.json
```
This works in JetBrains IDEs. As far as I know, both Visual Studio and Visual Studio Code don't support specifying JSON schema in YAML files (or at least I didn't find an easy way to do that). Both specifying the `$schema` property and specifying the comment above didn't work for me in both VS and VSC.