### PR TITLE
fix: actually hide the search icon when it's hidden by a theme

### DIFF
--- a/src/components/theme-builder/state/QueryBoxState.svelte.ts
+++ b/src/components/theme-builder/state/QueryBoxState.svelte.ts
@@ -169,7 +169,7 @@ export class QueryBoxState implements IState {
         x:Key="SearchIconStyle"
         BasedOn="{StaticResource BaseSearchIconStyle}"
         TargetType="{x:Type Path}">
-    ${this.getSearchIconStyleContents()}
+        ${this.getSearchIconStyleContents()}
     </Style>
     
     <!-- Progress bar under the query text box -->
@@ -192,6 +192,8 @@ export class QueryBoxState implements IState {
       `.trim();
     return `
         <Setter Property="Visibility" Value="Collapsed" />
+        <Setter Property="Width" Value="$0" />
+        <Setter Property="Height" Value="0" />
       `.trim();
   }
 

--- a/src/components/theme-builder/state/QueryBoxState.svelte.ts
+++ b/src/components/theme-builder/state/QueryBoxState.svelte.ts
@@ -192,7 +192,7 @@ export class QueryBoxState implements IState {
       `.trim();
     return `
         <Setter Property="Visibility" Value="Collapsed" />
-        <Setter Property="Width" Value="$0" />
+        <Setter Property="Width" Value="0" />
         <Setter Property="Height" Value="0" />
       `.trim();
   }


### PR DESCRIPTION
This PR fixes the search icon still being visible even if it was hidden in a theme. Closes #61. Thanks @dcog989 for the bug report and the proposed solution!