### PR TITLE
feat: add sorting options to plugins page

### DIFF
--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -50,11 +50,17 @@ const hasFeaturedPlugins = featured.length > 0;
         <select aria-label="Sort by" id="sort">
           <option value="name-asc" selected>Name (A-Z)</option>
           <option value="name-desc">Name (Z-A)</option>
+          <option value="first-release-desc">Release Date</option>
+          <option value="latest-release-desc">Last Updated</option>
         </select>
       </LabelValue>
     </div>
     <div id="store" class="plugin-grid">
-      {plugins.map(v => <Plugin plugin={v}/>)}
+      {plugins.map(v => <Plugin
+        plugin={v}
+        data-first-release-date={v.firstReleaseDate}
+        data-latest-release-date={v.latestReleaseDate}
+      />)}
     </div>
     <SectionSubheader>
       <div id="not-found" style="display: none;">No plugins found</div>
@@ -115,7 +121,12 @@ const store = document.querySelector("#store") as HTMLElement;
 
 const plugins = document.querySelectorAll("#store > .plugin") as NodeListOf<HTMLElement>;
 const defaultSortValue = "name-asc";
-const allowedSortValues = ["name-asc", "name-desc"];
+const allowedSortValues = [
+  "name-asc",
+  "name-desc",
+  "latest-release-desc",
+  "first-release-desc",
+];
 
 searchInput.addEventListener("input", onFilterChange);
 tagsSelect.addEventListener("change", onFilterChange);
@@ -213,6 +224,12 @@ function filterPlugins(): void {
   }
 }
 
+function getDateTimestamp(plugin: HTMLElement, attributeName: string): number {
+  const dateValue = plugin.getAttribute(attributeName) ?? "";
+  const timestamp = Date.parse(dateValue);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
 function applySort(): void {
   const sortValue = sortSelect.value;
 
@@ -221,14 +238,32 @@ function applySort(): void {
   }
 
   const sortedPlugins = Array.from(plugins).sort((a, b) => {
-    const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();
-    const titleB = b.querySelector(".name")!.textContent!.trim().toLowerCase();
+    switch (sortValue) {
+      case "latest-release-desc": {
+        const latestA = getDateTimestamp(a, "data-latest-release-date");
+        const latestB = getDateTimestamp(b, "data-latest-release-date");
+        return latestB - latestA;
+      }
 
-    if (sortValue === "name-desc") {
-      return titleB.localeCompare(titleA);
+      case "first-release-desc": {
+        const firstA = getDateTimestamp(a, "data-first-release-date");
+        const firstB = getDateTimestamp(b, "data-first-release-date");
+        return firstB - firstA;
+      }
+
+      case "name-desc": {
+        const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();
+        const titleB = b.querySelector(".name")!.textContent!.trim().toLowerCase();
+        return titleB.localeCompare(titleA);
+      }
+
+      case "name-asc":
+      default: {
+        const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();
+        const titleB = b.querySelector(".name")!.textContent!.trim().toLowerCase();
+        return titleA.localeCompare(titleB);
+      }
     }
-
-    return titleA.localeCompare(titleB);
   });
 
   // Re-appending existing plugin nodes moves them into sorted order (no duplicates) 

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -186,7 +186,11 @@ function updateUrlParams(): void {
     url.searchParams.delete("tags");
   }
 
-  url.searchParams.set("sort", sortValue);
+  if (sortValue !== DEFAULT_PLUGIN_SORT){
+    url.searchParams.set("sort", sortValue);
+  } else {
+    url.searchParams.delete("sort");
+  }
 
   history.replaceState(null, "", url);
 }

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -254,12 +254,6 @@ function applySort(): void {
         return firstB - firstA;
       }
 
-      case PLUGIN_SORTS.NAME_DESC.value: {
-        const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();
-        const titleB = b.querySelector(".name")!.textContent!.trim().toLowerCase();
-        return titleB.localeCompare(titleA);
-      }
-
       case PLUGIN_SORTS.NAME_ASC.value:
       default: {
         const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -154,7 +154,7 @@ tagsSelect.value = tagsParam;
 sortSelect.value = sortParam;
 
 filterPlugins();
-applySort();
+if(sortParam != DEFAULT_PLUGIN_SORT){applySort();}
 updateUrlParams();
 
 function onFilterChange(): void {

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -79,7 +79,8 @@ const hasFeaturedPlugins = featured.length > 0;
 .controls {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
+    column-gap: 20px;
+    row-gap: 12px;
     margin-top: 24px;
     position: sticky;
     top: 68px;

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -45,6 +45,13 @@ const hasFeaturedPlugins = featured.length > 0;
           {TAGS.map(v => <option value={v}>{v}</option>)}
         </select>
       </LabelValue>
+
+      <LabelValue label="Sort by">
+        <select aria-label="Sort by" id="sort">
+          <option value="name-asc" selected>Name (A-Z)</option>
+          <option value="name-desc">Name (Z-A)</option>
+        </select>
+      </LabelValue>
     </div>
     <div id="store" class="plugin-grid">
       {plugins.map(v => <Plugin plugin={v}/>)}
@@ -60,7 +67,7 @@ const hasFeaturedPlugins = featured.length > 0;
 
 .controls {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: 24px;
     margin-top: 24px;
     position: sticky;
@@ -102,36 +109,59 @@ import {TAGS} from "@/constants";
 
 const searchInput = document.querySelector("#search") as HTMLInputElement;
 const tagsSelect = document.querySelector("#tags") as HTMLSelectElement;
+const sortSelect = document.querySelector("#sort") as HTMLSelectElement;
 const notFound = document.querySelector("#not-found") as HTMLElement;
+const store = document.querySelector("#store") as HTMLElement;
 
 const plugins = document.querySelectorAll("#store > .plugin") as NodeListOf<HTMLElement>;
+const defaultSortValue = "name-asc";
+const allowedSortValues = ["name-asc", "name-desc"];
 
-searchInput.addEventListener("input", filterPlugins);
-tagsSelect.addEventListener("change", filterPlugins);
+searchInput.addEventListener("input", onFilterChange);
+tagsSelect.addEventListener("change", onFilterChange);
+sortSelect.addEventListener("change", onSortChange);
 
 const url = new URL(window.location.href);
 
 const searchParam = url.searchParams.get("search") ?? "";
 let tagsParam: any = url.searchParams.get("tags") ?? "";
+let sortParam = url.searchParams.get("sort") ?? defaultSortValue;
 
 if (!TAGS.includes(tagsParam)) {
   tagsParam = "";
 }
 
+if (!allowedSortValues.includes(sortParam)) {
+  sortParam = defaultSortValue;
+}
+
 searchInput.value = searchParam;
 tagsSelect.value = tagsParam;
+sortSelect.value = sortParam;
 
 filterPlugins();
+applySort();
+updateUrlParams();
 
-function filterPlugins(): void {
-  let foundAtLeastOnePlugin = false;
+function onFilterChange(): void {
+  filterPlugins();
+  applySort();
+  updateUrlParams();
+}
 
-  const searchValue = searchInput.value.toLowerCase();
+function onSortChange(): void {
+  applySort();
+  updateUrlParams();
+}
+
+function updateUrlParams(): void {
+  const searchValue = searchInput.value;
   const tagsValue = tagsSelect.value;
+  const sortValue = sortSelect.value;
 
   const url = new URL(window.location.href);
   if (searchValue.length > 0) {
-    url.searchParams.set("search", searchInput.value);
+    url.searchParams.set("search", searchValue);
   } else {
     url.searchParams.delete("search");
   }
@@ -142,7 +172,20 @@ function filterPlugins(): void {
     url.searchParams.delete("tags");
   }
 
+  if (allowedSortValues.includes(sortValue)) {
+    url.searchParams.set("sort", sortValue);
+  } else {
+    url.searchParams.delete("sort");
+  }
+
   history.replaceState(null, "", url);
+}
+
+function filterPlugins(): void {
+  let foundAtLeastOnePlugin = false;
+
+  const searchValue = searchInput.value.toLowerCase();
+  const tagsValue = tagsSelect.value;
 
   for (const plugin of plugins) {
     const title = plugin.querySelector(".name")!.textContent!.toLowerCase();
@@ -168,5 +211,27 @@ function filterPlugins(): void {
   } else {
     notFound.style.display = "block";
   }
+}
+
+function applySort(): void {
+  const sortValue = sortSelect.value;
+
+  if (!allowedSortValues.includes(sortValue)) {
+    return;
+  }
+
+  const sortedPlugins = Array.from(plugins).sort((a, b) => {
+    const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();
+    const titleB = b.querySelector(".name")!.textContent!.trim().toLowerCase();
+
+    if (sortValue === "name-desc") {
+      return titleB.localeCompare(titleA);
+    }
+
+    return titleA.localeCompare(titleB);
+  });
+
+  // Re-appending existing plugin nodes moves them into sorted order (no duplicates) 
+  store.append(...sortedPlugins);
 }
 </script>

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -8,6 +8,10 @@ import SectionSubheader from "@/components/SectionSubheader.astro";
 import LabelValue from "@/components/plugins/LabelValue.astro";
 import {TAGS} from "@/constants";
 import featuredPluginIds from "@/data/featured-plugins.yml";
+import {
+  DEFAULT_PLUGIN_SORT,
+  PLUGIN_SORT_LIST,
+} from "@/pages/plugins/pluginSortOptions";
 import Swiper from "@/components/Swiper.astro";
 
 const plugins = await getPluginsJson();
@@ -48,10 +52,11 @@ const hasFeaturedPlugins = featured.length > 0;
 
       <LabelValue label="Sort by">
         <select aria-label="Sort by" id="sort">
-          <option value="name-asc" selected>Name (A-Z)</option>
-          <option value="name-desc">Name (Z-A)</option>
-          <option value="first-release-desc">Release Date</option>
-          <option value="latest-release-desc">Last Updated</option>
+          {PLUGIN_SORT_LIST.map(option => (
+            <option value={option.value} selected={option.value === DEFAULT_PLUGIN_SORT}>
+              {option.label}
+            </option>
+          ))}
         </select>
       </LabelValue>
     </div>
@@ -112,6 +117,11 @@ const hasFeaturedPlugins = featured.length > 0;
 
 <script>
 import {TAGS} from "@/constants";
+import {
+  DEFAULT_PLUGIN_SORT,
+  isPluginSortValue,
+  PLUGIN_SORTS,
+} from "@/pages/plugins/pluginSortOptions";
 
 const searchInput = document.querySelector("#search") as HTMLInputElement;
 const tagsSelect = document.querySelector("#tags") as HTMLSelectElement;
@@ -120,14 +130,6 @@ const notFound = document.querySelector("#not-found") as HTMLElement;
 const store = document.querySelector("#store") as HTMLElement;
 
 const plugins = document.querySelectorAll("#store > .plugin") as NodeListOf<HTMLElement>;
-const defaultSortValue = "name-asc";
-const allowedSortValues = [
-  "name-asc",
-  "name-desc",
-  "latest-release-desc",
-  "first-release-desc",
-];
-
 searchInput.addEventListener("input", onFilterChange);
 tagsSelect.addEventListener("change", onFilterChange);
 sortSelect.addEventListener("change", onSortChange);
@@ -136,14 +138,14 @@ const url = new URL(window.location.href);
 
 const searchParam = url.searchParams.get("search") ?? "";
 let tagsParam: any = url.searchParams.get("tags") ?? "";
-let sortParam = url.searchParams.get("sort") ?? defaultSortValue;
+let sortParam = url.searchParams.get("sort") ?? DEFAULT_PLUGIN_SORT;
 
 if (!TAGS.includes(tagsParam)) {
   tagsParam = "";
 }
 
-if (!allowedSortValues.includes(sortParam)) {
-  sortParam = defaultSortValue;
+if (!isPluginSortValue(sortParam)) {
+  sortParam = DEFAULT_PLUGIN_SORT;
 }
 
 searchInput.value = searchParam;
@@ -183,11 +185,7 @@ function updateUrlParams(): void {
     url.searchParams.delete("tags");
   }
 
-  if (allowedSortValues.includes(sortValue)) {
-    url.searchParams.set("sort", sortValue);
-  } else {
-    url.searchParams.delete("sort");
-  }
+  url.searchParams.set("sort", sortValue);
 
   history.replaceState(null, "", url);
 }
@@ -233,31 +231,31 @@ function getDateTimestamp(plugin: HTMLElement, attributeName: string): number {
 function applySort(): void {
   const sortValue = sortSelect.value;
 
-  if (!allowedSortValues.includes(sortValue)) {
+  if (!isPluginSortValue(sortValue)) {
     return;
   }
 
   const sortedPlugins = Array.from(plugins).sort((a, b) => {
     switch (sortValue) {
-      case "latest-release-desc": {
+      case PLUGIN_SORTS.LATEST_RELEASE_DESC.value: {
         const latestA = getDateTimestamp(a, "data-latest-release-date");
         const latestB = getDateTimestamp(b, "data-latest-release-date");
         return latestB - latestA;
       }
 
-      case "first-release-desc": {
+      case PLUGIN_SORTS.FIRST_RELEASE_DESC.value: {
         const firstA = getDateTimestamp(a, "data-first-release-date");
         const firstB = getDateTimestamp(b, "data-first-release-date");
         return firstB - firstA;
       }
 
-      case "name-desc": {
+      case PLUGIN_SORTS.NAME_DESC.value: {
         const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();
         const titleB = b.querySelector(".name")!.textContent!.trim().toLowerCase();
         return titleB.localeCompare(titleA);
       }
 
-      case "name-asc":
+      case PLUGIN_SORTS.NAME_ASC.value:
       default: {
         const titleA = a.querySelector(".name")!.textContent!.trim().toLowerCase();
         const titleB = b.querySelector(".name")!.textContent!.trim().toLowerCase();
@@ -266,7 +264,7 @@ function applySort(): void {
     }
   });
 
-  // Re-appending existing plugin nodes moves them into sorted order (no duplicates) 
+  // Re-appending existing plugin nodes moves them into sorted order (no duplicates)
   store.append(...sortedPlugins);
 }
 </script>

--- a/src/pages/plugins/pluginSortOptions.ts
+++ b/src/pages/plugins/pluginSortOptions.ts
@@ -1,11 +1,7 @@
 export const PLUGIN_SORTS = {
   NAME_ASC: {
     value: "name-asc",
-    label: "Name (A-Z)",
-  },
-  NAME_DESC: {
-    value: "name-desc",
-    label: "Name (Z-A)",
+    label: "Name",
   },
   FIRST_RELEASE_DESC: {
     value: "first-release-desc",
@@ -13,7 +9,7 @@ export const PLUGIN_SORTS = {
   },
   LATEST_RELEASE_DESC: {
     value: "latest-release-desc",
-    label: "Last Updated",
+    label: "Updated Date",
   },
 } as const;
 

--- a/src/pages/plugins/pluginSortOptions.ts
+++ b/src/pages/plugins/pluginSortOptions.ts
@@ -1,0 +1,32 @@
+export const PLUGIN_SORTS = {
+  NAME_ASC: {
+    value: "name-asc",
+    label: "Name (A-Z)",
+  },
+  NAME_DESC: {
+    value: "name-desc",
+    label: "Name (Z-A)",
+  },
+  FIRST_RELEASE_DESC: {
+    value: "first-release-desc",
+    label: "Release Date",
+  },
+  LATEST_RELEASE_DESC: {
+    value: "latest-release-desc",
+    label: "Last Updated",
+  },
+} as const;
+
+export const PLUGIN_SORT_LIST = Object.values(PLUGIN_SORTS);
+
+export type PluginSortValue = typeof PLUGIN_SORTS[keyof typeof PLUGIN_SORTS]["value"];
+
+export const DEFAULT_PLUGIN_SORT: PluginSortValue = PLUGIN_SORTS.NAME_ASC.value;
+
+const PLUGIN_SORT_VALUE_SET = new Set<string>(
+  PLUGIN_SORT_LIST.map(option => option.value),
+);
+
+export function isPluginSortValue(value: string): value is PluginSortValue {
+  return PLUGIN_SORT_VALUE_SET.has(value);
+}


### PR DESCRIPTION
Add sorting dropdown to plugin page, with the following options:

- Name
- Release Date
- Updated Date

defined in pluginSortOptions.ts

Modified index.astro to add the dropdown and the clientside sorting functionality to match the existing filtering functionality

Related to this request:
https://www.reddit.com/r/FlowLauncher/comments/1s8gcrm/plugin_sort_by_date_created_or_updated/

## UI Change
<img width="1679" height="750" alt="image" src="https://github.com/user-attachments/assets/7aa2074f-02f7-43d5-9e1f-38e63aad28c3" />
