### PR TITLE
fix: prevent .plugin hover transform from overlapping .controls

### DIFF
--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -67,6 +67,7 @@ const hasFeaturedPlugins = featured.length > 0;
     top: 68px;
     background-color: var(--bg);
     padding: 12px 0;
+    z-index: 1;
 }
 
 .controls input,


### PR DESCRIPTION
## Problem
On the plugins page, hovering over a `.plugin` element applies `transform: translateY(-4px)`, which creates a new CSS stacking context. This caused the plugin element to render above the `.controls` element.

## Solution
Set `z-index: 1` on `.controls` to give it its own higher stacking context.

## UI Change
### Before
<img width="1257" height="624" alt="image" src="https://github.com/user-attachments/assets/233cf418-ae9a-4983-96b4-097c8aaf2ef7" />

### After
<img width="1259" height="601" alt="image" src="https://github.com/user-attachments/assets/7e5d7490-bfc6-41f3-9d73-1e19e94ff9d8" />

## Note
Not sure if this was actually intentional but it just seemed odd to me.