### PR TITLE
fix: extend .controls background to mask .plugin glow bleed

### DIFF
--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -68,6 +68,9 @@ const hasFeaturedPlugins = featured.length > 0;
     background-color: var(--bg);
     padding: 12px 0;
     z-index: 1;
+
+    // horizontal box shadow matching background to cover .plugin glow without causing layout changes or page overflow.
+    box-shadow: -24px 0 0 0 var(--bg), 24px 0 0 0 var(--bg);
 }
 
 .controls input,


### PR DESCRIPTION
## Problem
The glow effect from a .plugin, especially when hovered over, can show behind the .controls above it as it extends beyond the container width.

## Solution
Extend the background of .controls (--bg) using a box shadow to avoid any layout changes or overflow. This box shadow covers the glow from the .plugin behind it.

## Before
<img width="2172" height="364" alt="image" src="https://github.com/user-attachments/assets/394c28d6-40a3-4b38-aea7-e35b6dc6c5af" />

## After
<img width="2174" height="366" alt="image" src="https://github.com/user-attachments/assets/d60e97b3-6aab-409a-bee0-a3ce8fcc06ba" />
